### PR TITLE
hotfix: disable descriptive_stats_table which errors with wandb

### DIFF
--- a/src/psycop_model_training/config_schemas/eval.py
+++ b/src/psycop_model_training/config_schemas/eval.py
@@ -8,7 +8,7 @@ class EvalConfSchema(BaseModel):
     force: bool = False
     # Whether to force evaluation even if wandb is not "run". Used for testing.
 
-    descriptive_stats_table: bool = True
+    descriptive_stats_table: bool = False
     # Whether to generate table 1.
 
     top_n_feature_importances: int

--- a/src/psycop_model_training/model_eval/model_evaluator.py
+++ b/src/psycop_model_training/model_eval/model_evaluator.py
@@ -134,12 +134,6 @@ class ModelEvaluator:
             pipe_metadata=self.pipeline_metadata,
         )
 
-        artifacts = self._get_artifacts()
-
-        if self.upload_to_wandb:
-            for artifact in artifacts:
-                self.upload_artifact_to_wandb(artifact)
-
         roc_auc = roc_auc_score(
             self.eval_ds.y,
             self.eval_ds.y_hat_probs,
@@ -158,5 +152,11 @@ class ModelEvaluator:
         logging.info(  # pylint: disable=logging-not-lazy,logging-fstring-interpolation
             f"ROC AUC: {roc_auc}",
         )
+
+        artifacts = self._get_artifacts()
+
+        if self.upload_to_wandb:
+            for artifact in artifacts:
+                self.upload_artifact_to_wandb(artifact)
 
         return roc_auc


### PR DESCRIPTION
- [ ] I have battle-tested on Overtaci (RMAPPS1279)
- [ ] I have assigned ranges (e.g. `>=0.1, <0.2`) to all new dependencies (allows dependabot to keep dependency ranges wide for better compatibility)
- [ ] At least one of the commits is prefixed with either "fix:" or "feat:"

## Notes for reviewers
Reviewers can skip X, but should pay attention to Y.
