### PR TITLE
fix: added max bin creates different shapes

### DIFF
--- a/src/psycop_model_training/model_eval/base_artifacts/plots/time_from_first_positive_to_event.py
+++ b/src/psycop_model_training/model_eval/base_artifacts/plots/time_from_first_positive_to_event.py
@@ -86,7 +86,7 @@ def plot_time_from_first_positive_to_event(
         .reset_index()
     )
 
-    x_labels = list(bins)
+    x_labels = list(counts["time_from_first_positive_to_event_binned"])
     y_values = counts[0].to_list()
 
     plot = plot_basic_chart(


### PR DESCRIPTION
- [x] I have battle-tested on Overtaci (RMAPPS1279)
- [x] At least one of the commits is prefixed with either "fix:" or "feat:"

## Notes for reviewers
If max of series was > than bins, and an additional bin with max value was added, plots broke due to differences in shapes.