### PR TITLE
ci: restrict test comment to PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,17 +63,16 @@ jobs:
       - name: Test report on failures
         uses: EnricoMi/publish-unit-test-result-action@v2
         id: test_report_with_annotations
-        if: ${{ github.actor != 'dependabot[bot]' && (success() || failure()) }} # Do not run for dependabot, run whether tests failed or succeeded
+        if: ${{ github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (success() || failure()) }} # Do not run for dependabot, run whether tests failed or succeeded
         with:
           comment_mode: "failures"
           files: |
             pytest.xml
 
-      # if it is run on ubuntu-latest, python 3.9, then create the badge
       - name: Pytest coverage comment
         id: coverage-comment
         uses: MishaKav/pytest-coverage-comment@main
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (success() || failure()) }}
         with:
           create-new-comment: false
           report-only-changed-files: true


### PR DESCRIPTION
- [ ] I have battle-tested on Overtaci (RMAPPS1279)
- [ ] I have assigned ranges (e.g. `>=0.1, <0.2`) to all new dependencies (allows dependabot to keep dependency ranges wide for better compatibility)
- [ ] At least one of the commits is prefixed with either "fix:" or "feat:"

## Notes for reviewers
Reviewers can skip X, but should pay attention to Y.
