### PR TITLE
feat: add optional arg for id column name

### DIFF
--- a/src/psycop_model_training/application_modules/train_model/main.py
+++ b/src/psycop_model_training/application_modules/train_model/main.py
@@ -89,7 +89,9 @@ def train_model(
     # but rather logs to wandb and starts another run with a new combination of
     # hyperparameters
     roc_auc = post_wandb_setup_train_model(
-        cfg, artifacts=artifacts, id_col_name=id_col_name,
+        cfg,
+        artifacts=artifacts,
+        id_col_name=id_col_name,
     )
 
     return roc_auc

--- a/src/psycop_model_training/application_modules/train_model/main.py
+++ b/src/psycop_model_training/application_modules/train_model/main.py
@@ -44,6 +44,7 @@ def get_eval_dir(cfg: FullConfigSchema) -> Path:
 def post_wandb_setup_train_model(
     cfg: FullConfigSchema,
     artifacts: Optional[Sequence[ArtifactContainer]] = None,
+    id_col_name: Optional[str] = None,
 ) -> float:
     """Train a single model and evaluate it."""
     eval_dir_path = get_eval_dir(cfg)
@@ -60,6 +61,7 @@ def post_wandb_setup_train_model(
         outcome_col_name=outcome_col_name,
         train_col_names=train_col_names,
         n_splits=cfg.train.n_splits,
+        id_col_name=id_col_name,
     )
 
     roc_auc = ModelEvaluator(
@@ -78,6 +80,7 @@ def post_wandb_setup_train_model(
 def train_model(
     cfg: FullConfigSchema,
     artifacts: Optional[Sequence[ArtifactContainer]] = None,
+    id_col_name: Optional[str] = None,
 ) -> float:
     """Main function for training a single model."""
     WandbHandler(cfg=cfg).setup_wandb()
@@ -85,6 +88,8 @@ def train_model(
     # Try except block ensures process doesn't die in the case of an exception,
     # but rather logs to wandb and starts another run with a new combination of
     # hyperparameters
-    roc_auc = post_wandb_setup_train_model(cfg, artifacts=artifacts)
+    roc_auc = post_wandb_setup_train_model(
+        cfg, artifacts=artifacts, id_col_name=id_col_name
+    )
 
     return roc_auc

--- a/src/psycop_model_training/application_modules/train_model/main.py
+++ b/src/psycop_model_training/application_modules/train_model/main.py
@@ -89,7 +89,7 @@ def train_model(
     # but rather logs to wandb and starts another run with a new combination of
     # hyperparameters
     roc_auc = post_wandb_setup_train_model(
-        cfg, artifacts=artifacts, id_col_name=id_col_name
+        cfg, artifacts=artifacts, id_col_name=id_col_name,
     )
 
     return roc_auc

--- a/src/psycop_model_training/training/train_and_predict.py
+++ b/src/psycop_model_training/training/train_and_predict.py
@@ -41,6 +41,7 @@ def stratified_cross_validation(  # pylint: disable=too-many-locals
     train_col_names: list[str],
     outcome_col_name: str,
     n_splits: int,
+    id_col_name: Optional[str] = None,
 ) -> pd.DataFrame:
     """Performs stratified and grouped cross validation using the pipeline."""
     msg = Printer(timestamp=True)
@@ -52,10 +53,13 @@ def stratified_cross_validation(  # pylint: disable=too-many-locals
     msg.info("Creating folds")
     msg.info(f"Training on {X.shape[1]} columns and {X.shape[0]} rows")
 
+    if id_col_name is None:
+        id_col_name = cfg.data.col_name.id
+
     folds = StratifiedGroupKFold(n_splits=n_splits).split(
         X=X,
         y=y,
-        groups=train_df[cfg.data.col_name.id],
+        groups=train_df[id_col_name],
     )
 
     # Perform CV and get out of fold predictions
@@ -92,6 +96,7 @@ def crossval_train_and_predict(
     outcome_col_name: str,
     train_col_names: list[str],
     n_splits: int,
+    id_col_name: Optional[str] = None,
 ) -> EvalDataset:
     """Train model on cross validation folds and return evaluation dataset.
 
@@ -103,6 +108,7 @@ def crossval_train_and_predict(
         outcome_col_name: Name of the outcome column
         train_col_names: Names of the columns to use for training
         n_splits: Number of folds for cross validation.
+        id_col_name: name of id column
 
     Returns:
         Evaluation dataset
@@ -119,6 +125,7 @@ def crossval_train_and_predict(
         train_col_names=train_col_names,
         outcome_col_name=outcome_col_name,
         n_splits=n_splits,
+        id_col_name=id_col_name,
     )
 
     df = df.rename(columns={"oof_y_hat": "y_hat_prob"})
@@ -184,6 +191,7 @@ def train_and_predict(
     outcome_col_name: str,
     train_col_names: list[str],
     n_splits: Optional[int],
+    id_col_name: Optional[str] = None,
 ) -> EvalDataset:
     """Train model and return evaluation dataset.
 
@@ -195,6 +203,7 @@ def train_and_predict(
         outcome_col_name: Name of the outcome column
         train_col_names: Names of the columns to use for training
         n_splits: Number of folds for cross validation. If None, no cross validation is performed.
+        id_col_name: Name of the id col
 
     Returns:
         Evaluation dataset
@@ -223,6 +232,7 @@ def train_and_predict(
             outcome_col_name=outcome_col_name,
             train_col_names=train_col_names,
             n_splits=n_splits,
+            id_col_name=id_col_name,
         )
 
     return eval_dataset


### PR DESCRIPTION
- [x] I have battle-tested on Overtaci (RMAPPS1279)
- [x] At least one of the commits is prefixed with either "fix:" or "feat:"

Our ID is not usually dw_ek_borger (it's dw_ek_borger+admission_start_time), but when making the splits, we want to make sure that we are splitting by patient id too. Made some quick adjustments for it, but it can probably be done much simpler, and maybe it is not something we want on the main branch?